### PR TITLE
feat: add shell completion generation support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aad5b1b4de04fead402672b48897030eec1f3bfe1550776322f59f6d6e6a5677"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,6 +574,7 @@ dependencies = [
  "chrono",
  "chronoutil",
  "clap",
+ "clap_complete",
  "colored",
  "config",
  "ctor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ clap = { version = "4", features = [
     "unicode",
     "wrap_help",
 ] }
+clap_complete = "4"
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,19 @@ Interact with track.toggl.com via terminal.
 
 ## Shell completions
 
-WIP
+Generate shell completions for your shell:
+
+```bash
+# Bash
+fbtoggl --completions bash > ~/.local/share/bash-completion/completions/fbtoggl
+
+# Zsh
+fbtoggl --completions zsh > ~/.zfunc/_fbtoggl
+# Add to ~/.zshrc: fpath=(~/.zfunc $fpath)
+
+# Fish
+fbtoggl --completions fish > ~/.config/fish/completions/fbtoggl.fish
+```
 
 ## Usage
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,8 +2,10 @@ use crate::model::Range;
 use crate::types::TimeEntryId;
 use chrono::{DateTime, Duration, Local};
 use clap::{Parser, Subcommand, ValueEnum};
+use clap_complete::{Generator, Shell, generate};
 use jackdauer::duration;
 use serde::Serialize;
+use std::io;
 
 pub const APP_NAME: &str = "fbtoggl";
 
@@ -18,8 +20,12 @@ pub struct Options {
   #[arg(long)]
   pub debug: bool,
 
+  /// Generate shell completions
+  #[arg(long, value_enum)]
+  pub completions: Option<Shell>,
+
   #[clap(subcommand)]
-  pub subcommand: SubCommand,
+  pub subcommand: Option<SubCommand>,
 }
 
 #[derive(Debug, Clone, ValueEnum)]
@@ -53,7 +59,7 @@ pub enum SubCommand {
   Reports(Reports),
 }
 
-#[derive(Subcommand, Debug)]
+#[derive(Subcommand, Debug, Clone, Copy)]
 pub enum Settings {
   /// Initialize settings
   Init,
@@ -249,4 +255,8 @@ pub fn output_values_json<T: Serialize>(values: &[T]) {
       println!("{output}");
     }
   }
+}
+
+pub fn print_completions<G: Generator>(generator: G, cmd: &mut clap::Command) {
+  generate(generator, cmd, cmd.get_name().to_owned(), &mut io::stdout());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,9 @@
 //! This application provides a command-line interface to interact with
 //! Toggl Track's time tracking service.
 
-use crate::cli::{Clients, Options, SubCommand, TimeEntries};
+use crate::cli::{Clients, Format, Options, SubCommand, TimeEntries};
 use crate::config::init_settings_file;
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use cli::{Projects, Reports, Settings};
 use client::init_client;
 use report_client::init_report_client;
@@ -27,95 +27,151 @@ mod client_tests;
 
 fn main() -> anyhow::Result<()> {
   let options = Options::parse();
+
+  // Handle completion generation if requested
+  if let Some(shell) = options.completions {
+    let mut cmd = Options::command();
+    cli::print_completions(shell, &mut cmd);
+    return Ok(());
+  }
+
   let format = options.format;
   let debug = options.debug;
 
-  match options.subcommand {
-    SubCommand::Init => init_settings_file()?,
-    SubCommand::Settings(action) => match action {
-      Settings::Init => init_settings_file()?,
-    },
-    SubCommand::Projects(action) => match action {
-      Projects::List(list_projects) => {
-        let client = init_client()?;
-
-        commands::projects::list(
-          debug,
-          list_projects.include_archived,
-          &format,
-          &client,
-        )?;
-      }
-    },
-    SubCommand::Workspaces(_action) => {
-      let client = init_client()?;
-
-      commands::workspaces::list(debug, &format, &client)?;
-    }
-
-    SubCommand::TimeEntries(action) => match action {
-      TimeEntries::Create(time_entry) => {
-        let client = init_client()?;
-        commands::time_entries::create(debug, &format, &time_entry, &client)?;
-      }
-      TimeEntries::List(list_time_entries) => {
-        let client = init_client()?;
-        commands::time_entries::list(
-          debug,
-          &format,
-          &list_time_entries.range,
-          list_time_entries.missing,
-          &client,
-        )?;
-      }
-      TimeEntries::Start(time_entry) => {
-        let client = init_client()?;
-        commands::time_entries::start(debug, &format, &time_entry, &client)?;
-      }
-      TimeEntries::Stop(time_entry) => {
-        let client = init_client()?;
-        commands::time_entries::stop(debug, &format, &time_entry, &client)?;
-      }
-      TimeEntries::Delete(time_entry) => {
-        let client = init_client()?;
-        commands::time_entries::delete(debug, &format, &time_entry, &client)?;
-      }
-      TimeEntries::Details(time_entry) => {
-        let client = init_client()?;
-        commands::time_entries::details(debug, &format, &time_entry, &client)?;
-      }
-    },
-
-    SubCommand::Clients(action) => match action {
-      Clients::Create(create_client) => {
-        let client = init_client()?;
-        commands::clients::create(debug, &format, &create_client, &client)?;
-      }
-      Clients::List(list_clients) => {
-        let client = init_client()?;
-        commands::clients::list(
-          debug,
-          list_clients.include_archived,
-          &format,
-          &client,
-        )?;
-      }
-    },
-
-    SubCommand::Reports(action) => match action {
-      Reports::Detailed(detailed) => {
-        let client = init_client()?;
-        let report_client = init_report_client()?;
-
-        commands::reports::detailed(
-          debug,
-          &client,
-          &detailed.range,
-          &report_client,
-        )?;
-      }
-    },
+  if let Some(subcommand) = options.subcommand {
+    execute_subcommand(subcommand, debug, &format)?;
+  } else {
+    eprintln!(
+      "Error: A subcommand is required when not generating completions"
+    );
+    std::process::exit(1);
   }
 
+  Ok(())
+}
+
+fn execute_subcommand(
+  subcommand: SubCommand,
+  debug: bool,
+  format: &Format,
+) -> anyhow::Result<()> {
+  match subcommand {
+    SubCommand::Init => init_settings_file()?,
+    SubCommand::Settings(action) => handle_settings(action)?,
+    SubCommand::Projects(action) => handle_projects(action, debug, format)?,
+    SubCommand::Workspaces(_action) => handle_workspaces(debug, format)?,
+    SubCommand::TimeEntries(action) => {
+      handle_time_entries(action, debug, format)?;
+    }
+    SubCommand::Clients(action) => handle_clients(action, debug, format)?,
+    SubCommand::Reports(action) => handle_reports(action, debug)?,
+  }
+  Ok(())
+}
+
+fn handle_settings(action: Settings) -> anyhow::Result<()> {
+  match action {
+    Settings::Init => init_settings_file()?,
+  }
+  Ok(())
+}
+
+fn handle_projects(
+  action: Projects,
+  debug: bool,
+  format: &Format,
+) -> anyhow::Result<()> {
+  match action {
+    Projects::List(list_projects) => {
+      let client = init_client()?;
+      commands::projects::list(
+        debug,
+        list_projects.include_archived,
+        format,
+        &client,
+      )?;
+    }
+  }
+  Ok(())
+}
+
+fn handle_workspaces(debug: bool, format: &Format) -> anyhow::Result<()> {
+  let client = init_client()?;
+  commands::workspaces::list(debug, format, &client)?;
+  Ok(())
+}
+
+fn handle_time_entries(
+  action: TimeEntries,
+  debug: bool,
+  format: &Format,
+) -> anyhow::Result<()> {
+  let client = init_client()?;
+
+  match action {
+    TimeEntries::Create(time_entry) => {
+      commands::time_entries::create(debug, format, &time_entry, &client)?;
+    }
+    TimeEntries::List(list_time_entries) => {
+      commands::time_entries::list(
+        debug,
+        format,
+        &list_time_entries.range,
+        list_time_entries.missing,
+        &client,
+      )?;
+    }
+    TimeEntries::Start(time_entry) => {
+      commands::time_entries::start(debug, format, &time_entry, &client)?;
+    }
+    TimeEntries::Stop(time_entry) => {
+      commands::time_entries::stop(debug, format, &time_entry, &client)?;
+    }
+    TimeEntries::Delete(time_entry) => {
+      commands::time_entries::delete(debug, format, &time_entry, &client)?;
+    }
+    TimeEntries::Details(time_entry) => {
+      commands::time_entries::details(debug, format, &time_entry, &client)?;
+    }
+  }
+  Ok(())
+}
+
+fn handle_clients(
+  action: Clients,
+  debug: bool,
+  format: &Format,
+) -> anyhow::Result<()> {
+  let client = init_client()?;
+
+  match action {
+    Clients::Create(create_client) => {
+      commands::clients::create(debug, format, &create_client, &client)?;
+    }
+    Clients::List(list_clients) => {
+      commands::clients::list(
+        debug,
+        list_clients.include_archived,
+        format,
+        &client,
+      )?;
+    }
+  }
+  Ok(())
+}
+
+fn handle_reports(action: Reports, debug: bool) -> anyhow::Result<()> {
+  match action {
+    Reports::Detailed(detailed) => {
+      let client = init_client()?;
+      let report_client = init_report_client()?;
+      commands::reports::detailed(
+        debug,
+        &client,
+        &detailed.range,
+        &report_client,
+      )?;
+    }
+  }
   Ok(())
 }


### PR DESCRIPTION
- Add clap_complete dependency for completion generation
- Add --completions flag to generate completions for bash, zsh, fish, powershell, and elvish
- Refactor main.rs to reduce function size and improve code organization
- Update README.md with shell completion installation instructions
- Make subcommand optional to allow running with just --completions flag

🤖 Generated with [Claude Code](https://claude.ai/code)